### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -29,13 +29,25 @@ function set (obj, path, value) {
     if (node[key] === undefined) {
       node[key] = {};
     }
-    node = node[key];
+    node = isPrototypePolluted(key) ? {} : node[key];
   }
 
   key = path[i];
   node[key] = value;
 
   return obj;
+}
+
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ *
+ * @param {*} key
+ *
+ */
+
+function isPrototypePolluted (key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 module.exports = set;


### PR DESCRIPTION
### :bar_chart: Metadata *

`ganon` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-ganon

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const set = require('ganon/dist/set');
set({}, "__proto__.polluted", true);
console.log({}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i ganon # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/103163834-56ad7780-4829-11eb-8e29-e6a93f0db4bb.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
