### PR TITLE
fix prototype pollution in Set

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -26,6 +26,9 @@ function set (obj, path, value) {
   let i, key;
   for (i = 0; i < bound; i += 1) {
     key = path[i];
+    if (key == "__proto__" || key === "constructor") {
+      return obj;
+    }
     if (node[key] === undefined) {
       node[key] = {};
     }
@@ -33,6 +36,9 @@ function set (obj, path, value) {
   }
 
   key = path[i];
+  if (key == "__proto__" || (key === "constructor" && typeof node[key] === "function")) {
+    return obj;
+  }
   node[key] = value;
 
   return obj;

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -32,4 +32,9 @@ describe("set", () => {
   test("Set a value with an invalid path", () => {
     expect(() => set(obj, 42, 1337)).toThrow("Path should be a string or array");
   });
+
+  test("Set a value with a prototype pollution", () => {
+    expect(set(obj, ["a", "b", "__proto__", "pollution"], "kitties are evil")).not.toHaveProperty("a.b.__proto__.pollution", "kitties are evil");
+    expect(set(obj, ["a", "b", "constructor"], "kitties are evil")).not.toHaveProperty("a.b.constructor", "kitties are evil");
+  });
 });


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-ganon

### ⚙️ Description *

Fixing a security exploit

### 💻 Technical Description *

Fixing prototype pollution via the set function in set.js. If the path provided contains __proto__ or construct (and is already defined as a function on the given node) then prevent assigning the new value, (and return the object).

### 🐛 Proof of Concept (PoC) *

![01](https://user-images.githubusercontent.com/596881/104858564-14eb8a80-5918-11eb-80ed-b8751a9e95ac.png)

### 🔥 Proof of Fix (PoF) *

![02](https://user-images.githubusercontent.com/596881/104858565-15842100-5918-11eb-8461-f38cb916ffbe.png)

### 👍 User Acceptance Testing (UAT)

[added unit test to set.test.js](https://github.com/418sec/ganon/pull/2/commits/875fe3895fe10213746dee85dddd3309e4a3af02#diff-cef1f9ef2ead1912035cae13adf408adc48a50580edb9e0efeb05dc434355f0cR36)

run test before fix applied:
![04](https://user-images.githubusercontent.com/596881/104858647-b96dcc80-5918-11eb-9ca7-57e31edefa71.png)

run test after fix applied:
![03](https://user-images.githubusercontent.com/596881/104858648-ba066300-5918-11eb-8834-bc73b112beed.png)